### PR TITLE
Fixed installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Alternatively, use the installable version for your packet manager.
 
 ### Alternative: Building From Source
 
-If you have [Go](https://golang.org/) already installed, you can use `go get` to automatically download the latest version:
+If you have [Go](https://golang.org/) already installed, you can use `go install` to automatically download the latest version:
 
 ```bash
-go get -u github.com/gopasspw/git-credential-gopass
+go install  github.com/gopasspw/git-credential-gopass@latest
 ```
 
 ### Set Git Credential Helper


### PR DESCRIPTION
go get -u is no longer the way to do this as of Go 1.17. Replaced instructions to use go install.

Background:

        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.