### PR TITLE
[chore] Add integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Once you clone a Git repo that requires HTTP Authentication it will automaticall
 `git/HOST_PORT/REPO`. The secret must at least contain the password and the user like this:
 
 ```
-Secret: git/localhost_8080/gopass
+Secret: git/localhost_8080
 
 password
 login: username

--- a/git-credential_test.go
+++ b/git-credential_test.go
@@ -312,7 +312,7 @@ func TestIntegration(t *testing.T) {
 	// URL is something like http://127.0.0.1:12345 and we need to store the secret as
 	// `git/127.0.0.1_12345.txt`, i.e. first the `git/` prefix, then the URL with the port separated by `_`
 	// and finally `.txt` suffix for the plaintext "encryption" the test helper uses.
-	fn := filepath.Join(gp.StoreDir(""), "git", strings.Replace(strings.TrimPrefix(srv.URL, "http://"), ":", "_", -1)+".txt")
+	fn := filepath.Join(gp.StoreDir(""), "git", strings.ReplaceAll(strings.TrimPrefix(srv.URL, "http://"), ":", "_")+".txt")
 	require.NoError(t, os.MkdirAll(filepath.Dir(fn), 0o700))
 	require.NoError(t, os.WriteFile(fn, []byte("hunter2\nlogin: bob\n"), 0o600))
 

--- a/git-credential_test.go
+++ b/git-credential_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -270,7 +271,7 @@ func Test_getOptions(t *testing.T) {
 // First it tries to fetch from the remote without credentials, which should fail.
 // Then it sets the credentials in the password store and tries to fetch again, which should succeed.
 func TestIntegration(t *testing.T) {
-	if !fsutil.IsFile("git-credential-gopass") {
+	if !fsutil.IsFile("git-credential-gopass") || runtime.GOOS == "windows" {
 		t.Skip("Skipping integration test, git-credential-gopass binary not found. Use make test to run unit tests.")
 	}
 

--- a/git-credential_test.go
+++ b/git-credential_test.go
@@ -348,5 +348,6 @@ func prependPath(t *testing.T, env []string, path string) []string {
 		}
 	}
 	env = append(env, "PATH="+path)
+
 	return env
 }

--- a/git-credential_test.go
+++ b/git-credential_test.go
@@ -274,6 +274,12 @@ func TestIntegration(t *testing.T) {
 	// Create a temporary directory for the test
 	td := t.TempDir()
 
+	// Create a bin directory for the test
+	binDir := filepath.Join(td, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o700))
+
+	// TODO: Copy the credential helper binary to the bin directory.
+
 	// Create a new Git repository in the temporary directory
 	gitDir := filepath.Join(td, "test-repo")
 	gitutils.InitGitDir(t, gitDir)
@@ -305,6 +311,7 @@ func TestIntegration(t *testing.T) {
 
 	// Do an initial fetch, it should fail because we don't have credentials yet.
 	cmd = exec.CommandContext(ctx, "git", "-C", gitDir, "fetch", "origin")
+	// TODO: Add the location of the helper binary to the PATH.
 	err := cmd.Run()
 	require.Error(t, err, "fetch should fail without credentials")
 
@@ -318,5 +325,6 @@ func TestIntegration(t *testing.T) {
 
 	// Now fetch again, it should succeed
 	cmd = exec.CommandContext(ctx, "git", "-C", gitDir, "fetch", "origin")
+	// TODO: Add the location of the helper binary to the PATH.
 	require.NoError(t, cmd.Run(), "fetch should succeed with credentials")
 }

--- a/helpers/githost/githttp/context.go
+++ b/helpers/githost/githttp/context.go
@@ -6,10 +6,12 @@ type contextKey int
 
 const ctxKeyUsername contextKey = iota
 
+// WithUsername sets the username in the context.
 func WithUsername(ctx context.Context, username string) context.Context {
 	return context.WithValue(ctx, ctxKeyUsername, username)
 }
 
+// Username retrieves the username from the context.
 func Username(ctx context.Context) string {
 	if v, ok := ctx.Value(ctxKeyUsername).(string); ok {
 		return v

--- a/helpers/githost/githttp/context.go
+++ b/helpers/githost/githttp/context.go
@@ -1,0 +1,18 @@
+package githttp
+
+import "context"
+
+type contextKey int
+
+const ctxKeyUsername contextKey = iota
+
+func WithUsername(ctx context.Context, username string) context.Context {
+	return context.WithValue(ctx, ctxKeyUsername, username)
+}
+
+func Username(ctx context.Context) string {
+	if v, ok := ctx.Value(ctxKeyUsername).(string); ok {
+		return v
+	}
+	return ""
+}

--- a/helpers/githost/githttp/githttp.go
+++ b/helpers/githost/githttp/githttp.go
@@ -1,0 +1,201 @@
+package githttp
+
+import (
+	"bufio"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// GitPath is the path to the git binary
+var GitPath = "git"
+
+// Middleware for Basic Authentication
+func BasicAuthMiddleware(next http.HandlerFunc, username, password string) http.HandlerFunc {
+	// If no auth credentials provided via flags, skip auth
+	useAuth := (username != "" && password != "")
+	if !useAuth {
+		log.Println("Warning: No authentication configured (-auth-user and -auth-pass not set)")
+		return next
+	}
+	log.Println("Basic Authentication enabled")
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "" {
+			log.Printf("Auth Required for %s %s from %s", r.Method, r.URL.Path, r.RemoteAddr)
+			w.Header().Set("WWW-Authenticate", `Basic realm="Git Repository"`)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		// Expecting "Basic <base64data>"
+		const prefix = "Basic "
+		if !strings.HasPrefix(authHeader, prefix) {
+			log.Printf("Invalid Authorization header format from %s", r.RemoteAddr)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		encoded := authHeader[len(prefix):]
+		decoded, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			log.Printf("Error decoding base64 auth data from %s: %v", r.RemoteAddr, err)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		// Expecting "username:password"
+		parts := strings.SplitN(string(decoded), ":", 2)
+		if len(parts) != 2 {
+			log.Printf("Invalid decoded auth data format from %s", r.RemoteAddr)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		providedUser := parts[0]
+		providedPass := parts[1]
+
+		if providedUser != username || providedPass != password {
+			log.Printf("Authentication failed for user '%s' from %s", providedUser, r.RemoteAddr)
+			w.Header().Set("WWW-Authenticate", `Basic realm="Git Repository"`)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		// Authentication successful, pass the username down via context or header if needed
+		// For git-http-backend, we'll set REMOTE_USER environment variable later.
+		log.Printf("User '%s' authenticated successfully from %s", providedUser, r.RemoteAddr)
+
+		// Add the username to the request context
+		rc := r.WithContext(WithUsername(r.Context(), providedUser))
+
+		// Pass control to the next handler
+		next(w, rc)
+	}
+}
+
+// Core Git handler (now receives authenticated user if auth enabled)
+func GitHandler(root string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		authenticatedUser := Username(r.Context())
+
+		log.Printf("Handling %s %s for user '%s' from %s", r.Method, r.URL.String(), authenticatedUser, r.RemoteAddr)
+
+		// Basic path validation (prevent escaping root)
+		requestPath := filepath.Clean(r.URL.Path)
+		if strings.HasPrefix(requestPath, "..") || !strings.HasPrefix(requestPath, "/") {
+			http.Error(w, "Invalid path", http.StatusBadRequest)
+			return
+		}
+
+		// Prepare command execution
+		cmd := exec.Command(GitPath, "http-backend")
+
+		// Set required environment variables for git-http-backend
+		remoteAddr, _, _ := net.SplitHostPort(r.RemoteAddr)
+		env := []string{
+			fmt.Sprintf("GIT_PROJECT_ROOT=%s", root),
+			"GIT_HTTP_EXPORT_ALL=",
+			fmt.Sprintf("PATH_INFO=%s", requestPath),
+			fmt.Sprintf("REMOTE_ADDR=%s", remoteAddr),
+			fmt.Sprintf("REQUEST_METHOD=%s", r.Method),
+			fmt.Sprintf("QUERY_STRING=%s", r.URL.RawQuery),
+			fmt.Sprintf("CONTENT_TYPE=%s", r.Header.Get("Content-Type")),
+		}
+		// Pass authenticated user if available
+		if authenticatedUser != "" {
+			env = append(env, fmt.Sprintf("REMOTE_USER=%s", authenticatedUser))
+		}
+		cmd.Env = append(os.Environ(), env...)
+
+		// Pipe request body to command stdin for POST requests
+		if r.Method == "POST" && r.Body != nil {
+			cmd.Stdin = r.Body
+			defer r.Body.Close()
+		} else {
+			cmd.Stdin = nil
+		}
+
+		// Capture stdout and stderr
+		stdoutPipe, err := cmd.StdoutPipe()
+		if err != nil {
+			log.Printf("Error creating stdout pipe: %v", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		stderrPipe, err := cmd.StderrPipe()
+		if err != nil {
+			log.Printf("Error creating stderr pipe: %v", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+
+		// Start the command
+		if err := cmd.Start(); err != nil {
+			log.Printf("Error starting git http-backend: %v", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+
+		// Log stderr in the background
+		go func() {
+			scanner := bufio.NewScanner(stderrPipe)
+			for scanner.Scan() {
+				log.Printf("git-http-backend stderr: %s", scanner.Text())
+			}
+		}()
+
+		// Process CGI headers from stdout
+		stdoutReader := bufio.NewReader(stdoutPipe)
+		statusCode := http.StatusOK // Default status
+		for {
+			line, err := stdoutReader.ReadString('\n')
+			if err != nil {
+				if err != io.EOF {
+					log.Printf("Error reading CGI headers: %v", err)
+				}
+				break
+			}
+
+			line = strings.TrimSpace(line)
+			if line == "" {
+				// Empty line marks the end of headers
+				break
+			}
+
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) == 2 {
+				headerName := strings.TrimSpace(parts[0])
+				headerValue := strings.TrimSpace(parts[1])
+
+				if strings.EqualFold(headerName, "Status") {
+					fmt.Sscanf(headerValue, "%d", &statusCode)
+				} else {
+					w.Header().Set(headerName, headerValue)
+				}
+			} else {
+				log.Printf("Ignoring malformed CGI header line: %s", line)
+			}
+		}
+
+		// Write status code and copy remaining stdout (body) to response
+		w.WriteHeader(statusCode)
+		_, err = io.Copy(w, stdoutReader)
+		if err != nil {
+			log.Printf("Error copying git-http-backend output to response: %v", err)
+		}
+
+		// Wait for the command to finish
+		if err := cmd.Wait(); err != nil {
+			log.Printf("git http-backend command finished with error: %v", err)
+		}
+	}
+}

--- a/helpers/githost/main.go
+++ b/helpers/githost/main.go
@@ -1,18 +1,13 @@
 package main
 
 import (
-	"bufio"
-	"encoding/base64"
 	"flag"
-	"fmt"
-	"io"
 	"log"
-	"net"
 	"net/http"
-	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
+
+	"github.com/gopasspw/git-credential-gopass/helpers/githost/githttp"
 )
 
 var (
@@ -22,193 +17,6 @@ var (
 	authUser   = flag.String("auth-user", "gopass", "Username for Basic Authentication (required if auth-pass is set)")
 	authPass   = flag.String("auth-pass", "pass", "Password for Basic Authentication (required if auth-user is set)")
 )
-
-// Middleware for Basic Authentication
-func basicAuthMiddleware(next http.HandlerFunc, username, password string) http.HandlerFunc {
-	// If no auth credentials provided via flags, skip auth
-	useAuth := (username != "" && password != "")
-	if !useAuth {
-		log.Println("Warning: No authentication configured (-auth-user and -auth-pass not set)")
-		return next
-	}
-	log.Println("Basic Authentication enabled")
-
-	return func(w http.ResponseWriter, r *http.Request) {
-		authHeader := r.Header.Get("Authorization")
-		if authHeader == "" {
-			log.Printf("Auth Required for %s %s from %s", r.Method, r.URL.Path, r.RemoteAddr)
-			w.Header().Set("WWW-Authenticate", `Basic realm="Git Repository"`)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-
-		// Expecting "Basic <base64data>"
-		const prefix = "Basic "
-		if !strings.HasPrefix(authHeader, prefix) {
-			log.Printf("Invalid Authorization header format from %s", r.RemoteAddr)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-
-		encoded := authHeader[len(prefix):]
-		decoded, err := base64.StdEncoding.DecodeString(encoded)
-		if err != nil {
-			log.Printf("Error decoding base64 auth data from %s: %v", r.RemoteAddr, err)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-
-		// Expecting "username:password"
-		parts := strings.SplitN(string(decoded), ":", 2)
-		if len(parts) != 2 {
-			log.Printf("Invalid decoded auth data format from %s", r.RemoteAddr)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-
-		providedUser := parts[0]
-		providedPass := parts[1]
-
-		if providedUser != username || providedPass != password {
-			log.Printf("Authentication failed for user '%s' from %s", providedUser, r.RemoteAddr)
-			w.Header().Set("WWW-Authenticate", `Basic realm="Git Repository"`)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-
-		// Authentication successful, pass the username down via context or header if needed
-		// For git-http-backend, we'll set REMOTE_USER environment variable later.
-		log.Printf("User '%s' authenticated successfully from %s", providedUser, r.RemoteAddr)
-
-		// Pass control to the next handler
-		next(w, r)
-	}
-}
-
-// Core Git handler (now receives authenticated user if auth enabled)
-func gitHandler(root string) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		authenticatedUser := ""
-		// Basic check if auth was likely successful (for setting REMOTE_USER)
-		// Note: This relies on the middleware running first and assumes success if it reaches here with auth enabled.
-		if *authUser != "" && *authPass != "" {
-			// We can extract the username from the header again, or potentially pass via context
-			// For simplicity here, we'll just use the configured username since we only support one.
-			authenticatedUser = *authUser
-		}
-
-		log.Printf("Handling %s %s for user '%s' from %s", r.Method, r.URL.String(), authenticatedUser, r.RemoteAddr)
-
-		// Basic path validation (prevent escaping root)
-		requestPath := filepath.Clean(r.URL.Path)
-		if strings.HasPrefix(requestPath, "..") || !strings.HasPrefix(requestPath, "/") {
-			http.Error(w, "Invalid path", http.StatusBadRequest)
-			return
-		}
-
-		// Prepare command execution
-		cmd := exec.Command(*gitBinPath, "http-backend")
-
-		// Set required environment variables for git-http-backend
-		remoteAddr, _, _ := net.SplitHostPort(r.RemoteAddr)
-		env := []string{
-			fmt.Sprintf("GIT_PROJECT_ROOT=%s", root),
-			"GIT_HTTP_EXPORT_ALL=",
-			fmt.Sprintf("PATH_INFO=%s", requestPath),
-			fmt.Sprintf("REMOTE_ADDR=%s", remoteAddr),
-			fmt.Sprintf("REQUEST_METHOD=%s", r.Method),
-			fmt.Sprintf("QUERY_STRING=%s", r.URL.RawQuery),
-			fmt.Sprintf("CONTENT_TYPE=%s", r.Header.Get("Content-Type")),
-		}
-		// Pass authenticated user if available
-		if authenticatedUser != "" {
-			env = append(env, fmt.Sprintf("REMOTE_USER=%s", authenticatedUser))
-		}
-		cmd.Env = append(os.Environ(), env...)
-
-		// Pipe request body to command stdin for POST requests
-		if r.Method == "POST" && r.Body != nil {
-			cmd.Stdin = r.Body
-			defer r.Body.Close()
-		} else {
-			cmd.Stdin = nil
-		}
-
-		// Capture stdout and stderr
-		stdoutPipe, err := cmd.StdoutPipe()
-		if err != nil {
-			log.Printf("Error creating stdout pipe: %v", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-			return
-		}
-		stderrPipe, err := cmd.StderrPipe()
-		if err != nil {
-			log.Printf("Error creating stderr pipe: %v", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-			return
-		}
-
-		// Start the command
-		if err := cmd.Start(); err != nil {
-			log.Printf("Error starting git http-backend: %v", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-			return
-		}
-
-		// Log stderr in the background
-		go func() {
-			scanner := bufio.NewScanner(stderrPipe)
-			for scanner.Scan() {
-				log.Printf("git-http-backend stderr: %s", scanner.Text())
-			}
-		}()
-
-		// Process CGI headers from stdout
-		stdoutReader := bufio.NewReader(stdoutPipe)
-		statusCode := http.StatusOK // Default status
-		for {
-			line, err := stdoutReader.ReadString('\n')
-			if err != nil {
-				if err != io.EOF {
-					log.Printf("Error reading CGI headers: %v", err)
-				}
-				break
-			}
-
-			line = strings.TrimSpace(line)
-			if line == "" {
-				// Empty line marks the end of headers
-				break
-			}
-
-			parts := strings.SplitN(line, ":", 2)
-			if len(parts) == 2 {
-				headerName := strings.TrimSpace(parts[0])
-				headerValue := strings.TrimSpace(parts[1])
-
-				if strings.EqualFold(headerName, "Status") {
-					fmt.Sscanf(headerValue, "%d", &statusCode)
-				} else {
-					w.Header().Set(headerName, headerValue)
-				}
-			} else {
-				log.Printf("Ignoring malformed CGI header line: %s", line)
-			}
-		}
-
-		// Write status code and copy remaining stdout (body) to response
-		w.WriteHeader(statusCode)
-		_, err = io.Copy(w, stdoutReader)
-		if err != nil {
-			log.Printf("Error copying git-http-backend output to response: %v", err)
-		}
-
-		// Wait for the command to finish
-		if err := cmd.Wait(); err != nil {
-			log.Printf("git http-backend command finished with error: %v", err)
-		}
-	}
-}
 
 func main() {
 	flag.Parse()
@@ -232,9 +40,10 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error: git binary not found at '%s' or in PATH: %v", *gitBinPath, err)
 	}
+	githttp.GitPath = *gitBinPath
 
 	// Wrap the gitHandler with the auth middleware
-	finalHandler := basicAuthMiddleware(gitHandler(absRepoRoot), *authUser, *authPass)
+	finalHandler := githttp.BasicAuthMiddleware(githttp.GitHandler(absRepoRoot), *authUser, *authPass)
 	http.HandleFunc("/", finalHandler)
 
 	log.Printf("Starting Git HTTP server on %s", *listenAddr)


### PR DESCRIPTION
This change adds an integration test that will create a test repo, a test remote, spin up an HTTP server with basic auth and verify that we can fetch from the remote with valid credentials but not without.

This serves both as an example as well as a test of how this can be used.