### PR TITLE
chore: migrate from urfave/cli v2 to v3

### DIFF
--- a/git-credential.go
+++ b/git-credential.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -16,7 +17,7 @@ import (
 	"github.com/gopasspw/gopass/pkg/gopass"
 	"github.com/gopasspw/gopass/pkg/gopass/secrets"
 	"github.com/gopasspw/gopass/pkg/termio"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 // Stdout is exported for tests.
@@ -147,14 +148,13 @@ type gc struct {
 }
 
 // Before is executed before another git-credential command.
-func (s *gc) Before(c *cli.Context) error {
-	ctx := ctxutil.WithGlobalFlags(c)
+func (s *gc) Before(ctx context.Context, cmd *cli.Command) (context.Context, error) {
 	ctx = ctxutil.WithInteractive(ctx, false)
 	if !ctxutil.IsStdin(ctx) {
-		return fmt.Errorf("missing stdin from git")
+		return ctx, fmt.Errorf("missing stdin from git")
 	}
 
-	return nil
+	return ctx, nil
 }
 
 func filter(ls []string, prefix string) []string {
@@ -169,8 +169,8 @@ func filter(ls []string, prefix string) []string {
 	return out
 }
 
-func composePath(c *cli.Context, cred *gitCredentials) string {
-	store := c.String("store") + "/"
+func composePath(cmd *cli.Command, cred *gitCredentials) string {
+	store := cmd.String("store") + "/"
 	if store == "/" {
 		store = ""
 	}
@@ -185,8 +185,7 @@ func composePath(c *cli.Context, cred *gitCredentials) string {
 }
 
 // Get returns a credential to git.
-func (s *gc) Get(c *cli.Context) error {
-	ctx := ctxutil.WithGlobalFlags(c)
+func (s *gc) Get(ctx context.Context, cmd *cli.Command) error {
 	ctx = ctxutil.WithNoNetwork(ctx, true)
 	cred, err := parseGitCredentials(termio.Stdin)
 	if err != nil {
@@ -194,7 +193,7 @@ func (s *gc) Get(c *cli.Context) error {
 	}
 	// try git/host/username... If username is empty, simply try git/host
 
-	path := composePath(c, cred)
+	path := composePath(cmd, cred)
 	if _, err := s.gp.Get(ctx, path, "latest"); err != nil {
 		// if the looked up path is a directory with only one entry (e.g. one user per host), take the subentry instead
 		ls, err := s.gp.List(ctx)
@@ -239,14 +238,13 @@ func (s *gc) Get(c *cli.Context) error {
 }
 
 // Store stores a credential got from git.
-func (s *gc) Store(c *cli.Context) error {
-	ctx := ctxutil.WithGlobalFlags(c)
+func (s *gc) Store(ctx context.Context, cmd *cli.Command) error {
 	cred, err := parseGitCredentials(termio.Stdin)
 	if err != nil {
 		return fmt.Errorf("error: %w while parsing git-credential", err)
 	}
 
-	path := composePath(c, cred)
+	path := composePath(cmd, cred)
 	// This should never really be an issue because git automatically removes invalid credentials first
 	if _, err := s.gp.Get(ctx, path, "latest"); err == nil {
 		debug.Log(""+
@@ -278,14 +276,13 @@ func (s *gc) Store(c *cli.Context) error {
 }
 
 // Erase removes a credential got from git.
-func (s *gc) Erase(c *cli.Context) error {
-	ctx := ctxutil.WithGlobalFlags(c)
+func (s *gc) Erase(ctx context.Context, cmd *cli.Command) error {
 	cred, err := parseGitCredentials(termio.Stdin)
 	if err != nil {
 		return fmt.Errorf("error: %w while parsing git-credential", err)
 	}
 
-	path := composePath(c, cred)
+	path := composePath(cmd, cred)
 	if err := s.gp.Remove(ctx, path); err != nil {
 		fmt.Fprintln(os.Stderr, "gopass error: error while writing to store")
 	}
@@ -294,34 +291,33 @@ func (s *gc) Erase(c *cli.Context) error {
 }
 
 // Configure configures gopass as git's credential.helper.
-func (s *gc) Configure(c *cli.Context) error {
-	ctx := ctxutil.WithGlobalFlags(c)
-	options, err := getOptions(c)
+func (s *gc) Configure(ctx context.Context, cmd *cli.Command) error {
+	options, err := getOptions(cmd)
 	if err != nil {
 		return err
 	}
-	cmd := exec.CommandContext(ctx, "git", options...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	execCmd := exec.CommandContext(ctx, "git", options...)
+	execCmd.Stdout = os.Stdout
+	execCmd.Stderr = os.Stderr
 
-	return cmd.Run()
+	return execCmd.Run()
 }
 
-func getOptions(c *cli.Context) ([]string, error) {
+func getOptions(cmd *cli.Command) ([]string, error) {
 	options := []string{}
 	flags := 0
 	flag := "--global"
-	if c.Bool("local") {
+	if cmd.Bool("local") {
 		flag = "--local"
 		flags++
 	}
 
-	if c.Bool("global") {
+	if cmd.Bool("global") {
 		flag = "--global"
 		flags++
 	}
 
-	if c.Bool("system") {
+	if cmd.Bool("system") {
 		flag = "--system"
 		flags++
 	}
@@ -336,7 +332,7 @@ func getOptions(c *cli.Context) ([]string, error) {
 
 	options = append(options, "config", flag, "credential.helper")
 	store := "gopass"
-	if s := c.String("store"); s != "" {
+	if s := cmd.String("store"); s != "" {
 		store = fmt.Sprintf("gopass --store=%s", s)
 	}
 

--- a/git-credential_test.go
+++ b/git-credential_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http/httptest"
 	"os"
@@ -21,8 +22,32 @@ import (
 	"github.com/gopasspw/gopass/tests/gptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
+
+// testCmd creates a *cli.Command with the given flags set for use in tests.
+func testCmd(t *testing.T, ctx context.Context, flags map[string]string) *cli.Command {
+	t.Helper()
+
+	cmd := &cli.Command{
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "store"},
+			&cli.BoolFlag{Name: "global"},
+			&cli.BoolFlag{Name: "local"},
+			&cli.BoolFlag{Name: "system"},
+		},
+		Action: func(context.Context, *cli.Command) error { return nil },
+	}
+
+	args := []string{"test"}
+	for k, v := range flags {
+		args = append(args, "--"+k+"="+v)
+	}
+
+	_ = cmd.Run(ctx, args)
+
+	return cmd
+}
 
 func TestGitCredentialFormat(t *testing.T) {
 	t.Parallel()
@@ -122,37 +147,38 @@ func TestGitCredentialHelper(t *testing.T) { //nolint:paralleltest
 		termio.Stdin = os.Stdin
 	}()
 
-	c := gptest.CliCtx(ctx, t)
+	cmd := testCmd(t, ctx, nil)
 
 	// before without stdin
-	require.Error(t, act.Before(c))
+	_, err := act.Before(ctx, cmd)
+	require.Error(t, err)
 
 	// before with stdin
 	ctx = ctxutil.WithStdin(ctx, true)
-	c.Context = ctx
-	require.NoError(t, act.Before(c))
+	_, err = act.Before(ctx, cmd)
+	require.NoError(t, err)
 
 	s := "protocol=https\n" +
 		"host=example.com\n" +
 		"username=bob\n"
 
 	termio.Stdin = strings.NewReader(s)
-	require.NoError(t, act.Get(c))
+	require.NoError(t, act.Get(ctx, cmd))
 	assert.Empty(t, stdout.String())
 
 	termio.Stdin = strings.NewReader(s + "password=secr3=t\n")
-	require.NoError(t, act.Store(c))
+	require.NoError(t, act.Store(ctx, cmd))
 	stdout.Reset()
 
 	termio.Stdin = strings.NewReader(s)
-	require.NoError(t, act.Get(c))
+	require.NoError(t, act.Get(ctx, cmd))
 	read, err := parseGitCredentials(stdout)
 	require.NoError(t, err)
 	assert.Equal(t, "secr3=t", read.Password)
 	stdout.Reset()
 
 	termio.Stdin = strings.NewReader("host=example.com\n")
-	require.NoError(t, act.Get(c))
+	require.NoError(t, act.Get(ctx, cmd))
 	read, err = parseGitCredentials(stdout)
 	require.NoError(t, err)
 	assert.Equal(t, "secr3=t", read.Password)
@@ -160,19 +186,19 @@ func TestGitCredentialHelper(t *testing.T) { //nolint:paralleltest
 	stdout.Reset()
 
 	termio.Stdin = strings.NewReader(s)
-	require.NoError(t, act.Erase(c))
+	require.NoError(t, act.Erase(ctx, cmd))
 	assert.Empty(t, stdout.String())
 
 	termio.Stdin = strings.NewReader(s)
-	require.NoError(t, act.Get(c))
+	require.NoError(t, act.Get(ctx, cmd))
 	assert.Empty(t, stdout.String())
 
 	termio.Stdin = strings.NewReader("a")
-	require.Error(t, act.Get(c))
+	require.Error(t, act.Get(ctx, cmd))
 	termio.Stdin = strings.NewReader("a")
-	require.Error(t, act.Store(c))
+	require.Error(t, act.Store(ctx, cmd))
 	termio.Stdin = strings.NewReader("a")
-	require.Error(t, act.Erase(c))
+	require.Error(t, act.Erase(ctx, cmd))
 }
 
 func TestGitCredentialHelperWithStoreFlag(t *testing.T) { //nolint:paralleltest
@@ -189,38 +215,37 @@ func TestGitCredentialHelperWithStoreFlag(t *testing.T) { //nolint:paralleltest
 		termio.Stdin = os.Stdin
 	}()
 
-	c := gptest.CliCtxWithFlags(ctx, t, map[string]string{
+	cmd := testCmd(t, ctx, map[string]string{
 		"store": "teststore",
 	})
 
 	ctx = ctxutil.WithStdin(ctx, true)
-	c.Context = ctx
 
 	s := "protocol=https\n" +
 		"host=example.com\n" +
 		"username=bob\n"
 
 	termio.Stdin = strings.NewReader(s)
-	require.NoError(t, act.Get(c))
+	require.NoError(t, act.Get(ctx, cmd))
 	assert.Empty(t, stdout.String())
 
 	termio.Stdin = strings.NewReader(s + "password=secr3=t\n")
-	require.NoError(t, act.Store(c))
+	require.NoError(t, act.Store(ctx, cmd))
 	stdout.Reset()
 
 	termio.Stdin = strings.NewReader(s)
-	require.NoError(t, act.Get(c))
+	require.NoError(t, act.Get(ctx, cmd))
 	read, err := parseGitCredentials(stdout)
 	require.NoError(t, err)
 	assert.Equal(t, "secr3=t", read.Password)
 	stdout.Reset()
 
-	c = gptest.CliCtxWithFlags(ctx, t, map[string]string{
+	cmd = testCmd(t, ctx, map[string]string{
 		"store": "otherstore",
 	})
 
 	termio.Stdin = strings.NewReader(s)
-	require.NoError(t, act.Get(c))
+	require.NoError(t, act.Get(ctx, cmd))
 	assert.Empty(t, stdout.String())
 }
 
@@ -228,7 +253,7 @@ func Test_getOptions(t *testing.T) {
 	t.Parallel()
 
 	type args struct {
-		c *cli.Context
+		cmd *cli.Command
 	}
 
 	tests := []struct {
@@ -239,31 +264,31 @@ func Test_getOptions(t *testing.T) {
 	}{
 		{
 			name:    "without any flag",
-			args:    args{c: gptest.CliCtxWithFlags(t.Context(), t, map[string]string{})},
+			args:    args{cmd: testCmd(t, t.Context(), map[string]string{})},
 			want:    []string{"config", "--global", "credential.helper", "gopass"},
 			wantErr: false,
 		},
 		{
 			name:    "with local scope flag",
-			args:    args{c: gptest.CliCtxWithFlags(t.Context(), t, map[string]string{"local": "true"})},
+			args:    args{cmd: testCmd(t, t.Context(), map[string]string{"local": "true"})},
 			want:    []string{"config", "--local", "credential.helper", "gopass"},
 			wantErr: false,
 		},
 		{
 			name:    "with system scope flag",
-			args:    args{c: gptest.CliCtxWithFlags(t.Context(), t, map[string]string{"system": "true"})},
+			args:    args{cmd: testCmd(t, t.Context(), map[string]string{"system": "true"})},
 			want:    []string{"config", "--system", "credential.helper", "gopass"},
 			wantErr: false,
 		},
 		{
 			name:    "with local scope flag and store",
-			args:    args{c: gptest.CliCtxWithFlags(t.Context(), t, map[string]string{"local": "true", "store": "teststore"})},
+			args:    args{cmd: testCmd(t, t.Context(), map[string]string{"local": "true", "store": "teststore"})},
 			want:    []string{"config", "--local", "credential.helper", "gopass --store=teststore"},
 			wantErr: false,
 		},
 		{
 			name:    "error case with too many scope flags",
-			args:    args{c: gptest.CliCtxWithFlags(t.Context(), t, map[string]string{"local": "true", "system": "true"})},
+			args:    args{cmd: testCmd(t, t.Context(), map[string]string{"local": "true", "system": "true"})},
 			want:    []string{},
 			wantErr: true,
 		},
@@ -273,7 +298,7 @@ func Test_getOptions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := getOptions(tt.args.c)
+			got, err := getOptions(tt.args.cmd)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getOptions() error = %v, wantErr %v", err, tt.wantErr)
 
@@ -467,11 +492,11 @@ func Test_composePath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			c := gptest.CliCtxWithFlags(t.Context(), t, map[string]string{
+			cmd := testCmd(t, t.Context(), map[string]string{
 				"store": tt.store,
 			})
 
-			got := composePath(c, tt.credentials)
+			got := composePath(cmd, tt.credentials)
 			assert.Equal(t, tt.expected, got)
 		})
 	}
@@ -491,9 +516,8 @@ func TestGitCredentialHelperMultipleCredentialsPerUser(t *testing.T) { //nolint:
 		termio.Stdin = os.Stdin
 	}()
 
-	c := gptest.CliCtx(ctx, t)
+	cmd := testCmd(t, ctx, nil)
 	ctx = ctxutil.WithStdin(ctx, true)
-	c.Context = ctx
 
 	// Store first credential for myrepo
 	s1 := "protocol=https\n" +
@@ -502,7 +526,7 @@ func TestGitCredentialHelperMultipleCredentialsPerUser(t *testing.T) { //nolint:
 		"path=repo1\n"
 
 	termio.Stdin = strings.NewReader(s1 + "password=token1\n")
-	require.NoError(t, act.Store(c))
+	require.NoError(t, act.Store(ctx, cmd))
 	stdout.Reset()
 
 	// Store second credential for myrepo-other (same user, same host, different path)
@@ -512,12 +536,12 @@ func TestGitCredentialHelperMultipleCredentialsPerUser(t *testing.T) { //nolint:
 		"path=repo2\n"
 
 	termio.Stdin = strings.NewReader(s2 + "password=token2\n")
-	require.NoError(t, act.Store(c))
+	require.NoError(t, act.Store(ctx, cmd))
 	stdout.Reset()
 
 	// Retrieve first credential
 	termio.Stdin = strings.NewReader(s1)
-	require.NoError(t, act.Get(c))
+	require.NoError(t, act.Get(ctx, cmd))
 	read, err := parseGitCredentials(stdout)
 	require.NoError(t, err)
 	assert.Equal(t, "token1", read.Password)
@@ -525,7 +549,7 @@ func TestGitCredentialHelperMultipleCredentialsPerUser(t *testing.T) { //nolint:
 
 	// Retrieve second credential - should get different token
 	termio.Stdin = strings.NewReader(s2)
-	require.NoError(t, act.Get(c))
+	require.NoError(t, act.Get(ctx, cmd))
 	read, err = parseGitCredentials(stdout)
 	require.NoError(t, err)
 	assert.Equal(t, "token2", read.Password)
@@ -533,17 +557,17 @@ func TestGitCredentialHelperMultipleCredentialsPerUser(t *testing.T) { //nolint:
 
 	// Erase first credential
 	termio.Stdin = strings.NewReader(s1)
-	require.NoError(t, act.Erase(c))
+	require.NoError(t, act.Erase(ctx, cmd))
 	stdout.Reset()
 
 	// Try to retrieve first credential - should fail
 	termio.Stdin = strings.NewReader(s1)
-	require.NoError(t, act.Get(c))
+	require.NoError(t, act.Get(ctx, cmd))
 	assert.Empty(t, stdout.String())
 
 	// But second credential should still be available
 	termio.Stdin = strings.NewReader(s2)
-	require.NoError(t, act.Get(c))
+	require.NoError(t, act.Get(ctx, cmd))
 	read, err = parseGitCredentials(stdout)
 	require.NoError(t, err)
 	assert.Equal(t, "token2", read.Password)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/gopasspw/gopass v1.16.1
 	github.com/stretchr/testify v1.11.1
-	github.com/urfave/cli/v2 v2.27.7
+	github.com/urfave/cli/v3 v3.9.0
 )
 
 require (
@@ -34,6 +34,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/twpayne/go-pinentry/v4 v4.0.0 // indirect
+	github.com/urfave/cli/v2 v2.27.7 // indirect
 	github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 // indirect
 	github.com/zalando/go-keyring v0.2.6 // indirect
 	golang.org/x/crypto v0.46.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/twpayne/go-pinentry/v4 v4.0.0 h1:8WcNa+UDVRzz7y9OEEU/nRMX+UGFPCAvl5Xs
 github.com/twpayne/go-pinentry/v4 v4.0.0/go.mod h1:aXvy+awVXqdH+GS0ddQ7AKHZ3tXM6fJ2NK+e16p47PI=
 github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
 github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=
+github.com/urfave/cli/v3 v3.9.0 h1:AV9lIiPv3ukYnxunaCUsHnEozptYmDN2F0+yWqLMn/c=
+github.com/urfave/cli/v3 v3.9.0/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 h1:FnBeRrxr7OU4VvAzt5X7s6266i6cSVkkFPS0TuXWbIg=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/zalando/go-keyring v0.2.6 h1:r7Yc3+H+Ux0+M72zacZoItR3UDxeWfKTcabvkI8ua9s=

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/gopass/api"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 const (
@@ -54,73 +54,73 @@ func main() {
 		gp: gp,
 	}
 
-	app := cli.NewApp()
-	app.Name = name
-	app.Version = getVersion().String()
-	app.Usage = `Use "gopass" as git's credential.helper`
-	app.Description = "" +
-		"This command allows you to cache your git-credentials with gopass." +
-		"Activate by using `git config --global credential.helper gopass`"
-	app.EnableBashCompletion = true
-	app.Flags = []cli.Flag{
-		&cli.StringFlag{
-			Name:  "store",
-			Usage: "First part of path to find the secret.",
+	app := &cli.Command{
+		Name:    name,
+		Version: getVersion().String(),
+		Usage:   `Use "gopass" as git's credential.helper`,
+		Description: "This command allows you to cache your git-credentials with gopass." +
+			"Activate by using `git config --global credential.helper gopass`",
+		EnableShellCompletion: true,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "store",
+				Usage: "First part of path to find the secret.",
+			},
 		},
-	}
-	app.Commands = []*cli.Command{
-		{
-			Name:   "get",
-			Hidden: true,
-			Action: gc.Get,
-			Before: gc.Before,
-		},
-		{
-			Name:   "store",
-			Hidden: true,
-			Action: gc.Store,
-			Before: gc.Before,
-		},
-		{
-			Name:   "erase",
-			Hidden: true,
-			Action: gc.Erase,
-			Before: gc.Before,
-		},
-		{
-			Name:        "configure",
-			Description: "This command configures git-credential-gopass as git's credential.helper",
-			Action:      gc.Configure,
-			Flags: []cli.Flag{
-				&cli.BoolFlag{
-					Name:  "global",
-					Usage: "Install for current user",
+		Commands: []*cli.Command{
+			{
+				Name:   "get",
+				Hidden: true,
+				Action: gc.Get,
+				Before: gc.Before,
+			},
+			{
+				Name:   "store",
+				Hidden: true,
+				Action: gc.Store,
+				Before: gc.Before,
+			},
+			{
+				Name:   "erase",
+				Hidden: true,
+				Action: gc.Erase,
+				Before: gc.Before,
+			},
+			{
+				Name:        "configure",
+				Description: "This command configures git-credential-gopass as git's credential.helper",
+				Action:      gc.Configure,
+				Flags: []cli.Flag{
+					&cli.BoolFlag{
+						Name:  "global",
+						Usage: "Install for current user",
+					},
+					&cli.BoolFlag{
+						Name:  "local",
+						Usage: "Install for current repository only",
+					},
+					&cli.BoolFlag{
+						Name:  "system",
+						Usage: "Install for all users, requires superuser rights",
+					},
+					&cli.StringFlag{
+						Name:  "store",
+						Usage: "First part of path to find the secret.",
+					},
 				},
-				&cli.BoolFlag{
-					Name:  "local",
-					Usage: "Install for current repository only",
-				},
-				&cli.BoolFlag{
-					Name:  "system",
-					Usage: "Install for all users, requires superuser rights",
-				},
-				&cli.StringFlag{
-					Name:  "store",
-					Usage: "First part of path to find the secret.",
+			},
+			{
+				Name: "version",
+				Action: func(ctx context.Context, cmd *cli.Command) error {
+					cli.VersionPrinter(cmd)
+
+					return nil
 				},
 			},
 		},
-		{
-			Name: "version",
-			Action: func(c *cli.Context) error {
-				cli.VersionPrinter(c)
-
-				return nil
-			},
-		},
 	}
 
-	if err := app.RunContext(ctx, os.Args); err != nil {
+	if err := app.Run(ctx, os.Args); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
- Update import path to github.com/urfave/cli/v3
- Replace cli.NewApp() with &cli.Command{} struct literal
- Replace EnableBashCompletion with EnableShellCompletion
- Replace app.RunContext() with cmd.Run()
- Update all handler signatures to func(context.Context, *cli.Command) error
- Update BeforeFunc signature to return (context.Context, error)
- Replace *cli.Context receivers with *cli.Command in all methods
- Remove ctxutil.WithGlobalFlags() calls (context now passed directly)
- Replace gptest.CliCtx/CliCtxWithFlags in tests with local testCmd helper
- Update all test call sites to pass (ctx, cmd) arguments